### PR TITLE
Implement external account binding (WIP)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,18 @@ services:
     volumes:
       - ./pebble-config.json:/pebble-config.json
       - ./certs:/certs
+  pebble-eab:
+    image: letsencrypt/pebble:latest
+    command: pebble -config /pebble-config-eab.json -strict -dnsserver 10.30.50.3:8053
+    ports:
+      - 14001:14000 # HTTPS ACME API
+      - 15001:15000 # HTTPS Management API
+    networks:
+      acmenet:
+        ipv4_address: 10.30.50.4
+    volumes:
+      - ./pebble-config-eab.json:/pebble-config-eab.json
+      - ./certs:/certs
   challtestsrv:
     image: letsencrypt/pebble-challtestsrv:latest
     command: pebble-challtestsrv -defaultIPv6 "" -defaultIPv4 10.30.50.3

--- a/pebble-config-eab.json
+++ b/pebble-config-eab.json
@@ -1,0 +1,16 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14000",
+    "managementListenAddress": "0.0.0.0:15000",
+    "certificate": "certs/localhost/cert.pem",
+    "privateKey": "certs/localhost/key.pem",
+    "httpPort": 5002,
+    "tlsPort": 5001,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": true,
+    "externalAccountMACKeys": {
+      "kid-1": "zWNDZM6eQGHWpSRTPal5eIUYFTu7EajVIoguysqZ9wG44nMEtx3MUAsUDkMTQ12W",
+      "kid-2": "b10lLJs8l1GPIzsLP0s6pMt8O0XVGnfTaCeROxQM0BIt2XrJMDHJZBM5NuQmQJQH"
+    }
+  }
+}

--- a/src/account.rs
+++ b/src/account.rs
@@ -162,8 +162,7 @@ impl AccountBuilder {
     let url = self.directory.new_account_url.clone();
 
     let external_account_binding = if let Some(eab_config) = &self.eab_config {
-      let payload =
-        b64(&serde_json::to_vec(&Jwk::new(&eab_config.private_key)).unwrap());
+      let payload = serde_json::to_string(&Jwk::new(&private_key)).unwrap();
 
       Some(jws(
         &url,

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -161,6 +161,7 @@ impl Directory {
   ) -> Result<reqwest::Response, Error> {
     let nonce = self.get_nonce().await?;
     let body = jws(url, Some(nonce), &payload, pkey, account_id.clone())?;
+    let body = serde_json::to_vec(&body)?;
     let resp = self
       .http_client
       .post(url)

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -160,7 +160,7 @@ impl Directory {
     account_id: &Option<String>,
   ) -> Result<reqwest::Response, Error> {
     let nonce = self.get_nonce().await?;
-    let body = jws(url, nonce, &payload, pkey, account_id.clone())?;
+    let body = jws(url, Some(nonce), &payload, pkey, account_id.clone())?;
     let resp = self
       .http_client
       .post(url)

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -76,6 +76,7 @@ impl DirectoryBuilder {
 /// Must be created through a [`DirectoryBuilder`].
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
+#[allow(unused)]
 pub struct Directory {
   #[serde(skip)]
   pub(crate) http_client: reqwest::Client,
@@ -90,7 +91,7 @@ pub struct Directory {
   #[serde(rename = "revokeCert")]
   pub(crate) revoke_cert_url: String,
   #[serde(rename = "keyChange")]
-  pub(crate) key_change_url: String,
+  pub(crate) key_change_url: Option<String>,
   #[serde(rename = "newAuthz")]
   pub(crate) new_authz_url: Option<String>,
   /// Optional metadata describing a directory.

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 struct JwsHeader {
+  #[serde(skip_serializing_if = "Option::is_none")]
   nonce: Option<String>,
   alg: String,
   url: String,


### PR DESCRIPTION
This PR implements [external account binding](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4) as specified in RFC 8555 and adds a test for it.

The functionality is all there, but I'm marking this as WIP as there are a few things I'd like to clean up (tests and error handling). If the general approach is acceptable, I'm happy to complete those tasks before merging.