### PR TITLE
Add P-256 account key support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install OpenSSL
+        run: apt install libssl-dev
       - name: Lint
         run: |
           cargo clippy --all-targets --locked --release -- -D clippy::all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install rust
         uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: 1.51.0
+          rust-version: 1.80.1
       - name: Install clippy and rustfmt
         run: |
           rustup component add clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "acme2"
 version = "0.5.1"
 dependencies = [
+ "asn1",
  "base64",
  "hyper",
  "openssl",
@@ -16,6 +17,27 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "asn1"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2affba5e62ee09eeba078f01a00c4aed45ac4287e091298eccbb0d4802efbdc5"
+dependencies = [
+ "asn1_derive",
+ "chrono",
+]
+
+[[package]]
+name = "asn1_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfab79c195875e5aef2bd20b4c8ed8d43ef9610bcffefbbcf66f88f555cc78af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -65,6 +87,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -385,6 +417,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +678,7 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 serde = {version = "1.0", features=["derive"]}
-serde_json = { version = "1.0", features=["preserve_order"]}
+serde_json = {version = "1.0", features=["preserve_order"]}
 base64 = "0.13"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 serde = {version = "1.0", features=["derive"]}
-serde_json = "1.0"
+serde_json = { version = "1.0", features=["preserve_order"]}
 base64 = "0.13"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
@@ -20,6 +20,7 @@ tokio = { version = "1.0", features = [ "time", "fs" ] }
 tracing = "0.1"
 tracing-futures = "0.2"
 thiserror = "1.0.24"
+asn1 = "0.13.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -220,23 +220,8 @@ impl Challenge {
     if let Some(token) = self.token.clone() {
       let account = self.account.clone().unwrap();
 
-      let jwk = Jwk::new(&account.private_key.clone().unwrap()).unwrap();
-      let value = serde_json::to_value(&jwk).unwrap();
-      let map = match value {
-          serde_json::Value::Object(m) => m,
-          _ => unreachable!(),
-      };
-      let mut keys: Vec<_> = map.keys().collect();
-      keys.sort();
-      let mut map_sorted = serde_json::Map::new();
-      for k in keys {
-          map_sorted.insert(k.clone(), map[k].clone());
-      }
-      println!("map sorted: {:?}", map_sorted);
-      let serialized = serde_json::to_string(&serde_json::Value::Object(map_sorted)).unwrap();
-      println!("serialized: {}", serialized);
-
-      let thumbprint = b64(&hash(MessageDigest::sha256(), serialized.as_bytes())?);
+      let jwk = Jwk::new(&account.private_key.clone().unwrap())?;
+      let thumbprint = jwk.thumbprint()?;
       let key_authorization = format!("{}.{}", token, thumbprint);
 
       Ok(Some(key_authorization))

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -220,7 +220,8 @@ impl Challenge {
     if let Some(token) = self.token.clone() {
       let account = self.account.clone().unwrap();
 
-      let value = serde_json::to_value(&Jwk::new(&account.private_key.clone().unwrap())).unwrap();
+      let jwk = Jwk::new(&account.private_key.clone().unwrap()).unwrap();
+      let value = serde_json::to_value(&jwk).unwrap();
       let map = match value {
           serde_json::Value::Object(m) => m,
           _ => unreachable!(),

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -160,7 +160,7 @@ impl Directory {
     account_id: &Option<String>,
   ) -> Result<reqwest::Response, Error> {
     let nonce = self.get_nonce().await?;
-    let body = jws(url, nonce, &payload, pkey, account_id.clone())?;
+    let body = jws(url, nonce, payload, pkey, account_id.clone())?;
     let resp = self
       .http_client
       .post(url)
@@ -198,7 +198,7 @@ impl Directory {
       attempt += 1;
 
       let resp = self
-        .authenticated_request_raw(url, &payload, &pkey, &account_id)
+        .authenticated_request_raw(url, payload, pkey, account_id)
         .await?;
 
       let headers = resp.headers().clone();

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -177,19 +177,3 @@ pub(crate) fn jws(
   println!("{}", res);
   Ok(res)
 }
-
-#[cfg(test)]
-mod test {
-  use super::*;
-  use openssl::ec::{EcGroup, EcKey};
-
-  #[test]
-  fn test_jws() {
-    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
-    let key = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
-    assert_eq!(
-      "",
-      jws("http://foo", "bar".into(), "payload", &key, None).unwrap()
-    )
-  }
-}

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -177,11 +177,9 @@ pub(crate) fn jws(
   let signature = jwk.sign_sha256(pkey, to_sign.as_bytes())?;
   let signature_b64 = b64(&signature);
 
-  let res = serde_json::to_string(&json!({
+  Ok(serde_json::to_string(&json!({
     "protected": protected_b64,
     "payload": payload_b64,
     "signature": signature_b64
-  }))?;
-  println!("{}", res);
-  Ok(res)
+  }))?)
 }

--- a/src/jws.rs
+++ b/src/jws.rs
@@ -1,6 +1,9 @@
 use crate::error::*;
 use crate::helpers::*;
+use openssl::bn::BigNumContext;
+use openssl::ec::PointConversionForm;
 use openssl::hash::MessageDigest;
+use openssl::nid::Nid;
 use openssl::pkey::PKey;
 use openssl::pkey::Private;
 use openssl::sign::Signer;
@@ -19,19 +22,44 @@ struct JwsHeader {
   jwk: Option<Jwk>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub(crate) struct Jwk {
-  e: String,
-  kty: String,
-  n: String,
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(tag = "kty")]
+pub(crate) enum Jwk {
+  RSA { e: String, n: String },
+  EC { crv: String, x: String, y: String },
 }
 
 impl Jwk {
   pub fn new(pkey: &PKey<Private>) -> Jwk {
-    Jwk {
-      e: b64(&pkey.rsa().unwrap().e().to_vec()),
-      kty: "RSA".to_string(),
-      n: b64(&pkey.rsa().unwrap().n().to_vec()),
+    // TODO: don't panic
+    if let Ok(r) = pkey.rsa() {
+      Jwk::RSA {
+        e: b64(&r.e().to_vec()),
+        n: b64(&r.n().to_vec()),
+      }
+    } else if let Ok(e) = pkey.ec_key() {
+      if e.group().curve_name() != Some(Nid::X9_62_PRIME256V1) {
+        panic!("{:?}", e.group().curve_name())
+      }
+      let public = e.public_key();
+
+      let mut ctx = BigNumContext::new().unwrap();
+      let bytes = public
+        .to_bytes(e.group(), PointConversionForm::UNCOMPRESSED, &mut ctx)
+        .unwrap();
+
+      assert_eq!(65, bytes.len());
+      let bytes = &bytes[1..]; // truncate 0x04
+      let x = &bytes[0..bytes.len() / 2];
+      let y = &bytes[bytes.len() / 2..];
+
+      Jwk::EC {
+        crv: "P-256".into(),
+        x: b64(x),
+        y: b64(y),
+      }
+    } else {
+      panic!("?")
     }
   }
 }
@@ -44,10 +72,16 @@ pub(crate) fn jws(
   account_id: Option<String>,
 ) -> Result<String, Error> {
   let payload_b64 = b64(&payload.as_bytes());
+  let jwk = Jwk::new(&pkey);
 
   let mut header = JwsHeader {
     nonce,
-    alg: "RS256".into(),
+    alg: match &jwk {
+      Jwk::RSA { .. } => "RS256",
+      Jwk::EC { crv, .. } if crv == "P-256" => "ES256",
+      _ => unimplemented!(),
+    }
+    .into(),
     url: url.to_string(),
     ..Default::default()
   };
@@ -55,21 +89,61 @@ pub(crate) fn jws(
   if let Some(kid) = account_id {
     header.kid = kid.into();
   } else {
-    header.jwk = Some(Jwk::new(&pkey));
+    header.jwk = Some(jwk.clone());
   }
 
   let protected_b64 = b64(&serde_json::to_string(&header)?.into_bytes());
 
-  let signature_b64 = {
+  let signature = {
     let mut signer = Signer::new(MessageDigest::sha256(), pkey)?;
     signer
       .update(&format!("{}.{}", protected_b64, payload_b64).into_bytes())?;
-    b64(&signer.sign_to_vec()?)
+    let bytes = signer.sign_to_vec()?;
+    match &jwk {
+      Jwk::RSA { .. } => bytes,
+      Jwk::EC { .. } => {
+        let result: asn1::ParseResult<_> = asn1::parse(&bytes, |d| {
+          return d.read_element::<asn1::Sequence>()?.parse(|d| {
+            let r = d.read_element::<asn1::BigInt>()?;
+            let s = d.read_element::<asn1::BigInt>()?;
+            return Ok((r, s));
+          });
+        });
+        let result = result.unwrap();
+        let mut bytes = Vec::new();
+        let r = result.0.as_bytes();
+        let s = result.1.as_bytes();
+        let r = &r[r.len() - 32..];
+        let s = &s[s.len() - 32..];
+        bytes.extend_from_slice(r);
+        bytes.extend_from_slice(s);
+        bytes
+      }
+    }
   };
+  let signature_b64 = b64(&signature);
 
-  Ok(serde_json::to_string(&json!({
+  let res = serde_json::to_string(&json!({
     "protected": protected_b64,
     "payload": payload_b64,
     "signature": signature_b64
-  }))?)
+  }))?;
+  println!("{}", res);
+  Ok(res)
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use openssl::ec::{EcGroup, EcKey};
+
+  #[test]
+  fn test_jws() {
+    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
+    let key = PKey::from_ec_key(EcKey::generate(&group).unwrap()).unwrap();
+    assert_eq!(
+      "",
+      jws("http://foo", "bar".into(), "payload", &key, None).unwrap()
+    )
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,10 +131,10 @@ pub use order::*;
 #[cfg(test)]
 mod tests {
   use crate::*;
+  use openssl::pkey::{PKey, Private};
   use serde_json::json;
   use std::sync::Arc;
   use std::time::Duration;
-  use openssl::pkey::{PKey, Private};
 
   async fn pebble_http_client() -> reqwest::Client {
     let raw = tokio::fs::read("./certs/pebble.minica.pem").await.unwrap();
@@ -210,7 +210,7 @@ mod tests {
       .contact(vec!["mailto:hello@lcas.dev".to_string()])
       .terms_of_service_agreed(true);
     if let Some(p) = pkey {
-        builder.private_key(p);
+      builder.private_key(p);
     }
 
     let account = builder.build().await.unwrap();
@@ -232,13 +232,13 @@ mod tests {
 
   #[tokio::test]
   async fn test_account_creation_pebble_rsa() {
-      test_account_creation_pebble(None).await;
+    test_account_creation_pebble(None).await;
   }
 
   #[tokio::test]
   async fn test_account_creation_pebble_ec() {
-      let pkey = gen_ec_p256_private_key().unwrap();
-      test_account_creation_pebble(Some(pkey)).await;
+    let pkey = gen_ec_p256_private_key().unwrap();
+    test_account_creation_pebble(Some(pkey)).await;
   }
 
   #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ mod tests {
   use serde_json::json;
   use std::sync::Arc;
   use std::time::Duration;
+  use openssl::pkey::{PKey, Private};
 
   async fn pebble_http_client() -> reqwest::Client {
     let raw = tokio::fs::read("./certs/pebble.minica.pem").await.unwrap();
@@ -201,17 +202,18 @@ mod tests {
     assert_eq!(meta.website, None);
   }
 
-  #[tokio::test]
-  async fn test_account_creation_pebble() {
+  async fn test_account_creation_pebble(pkey: Option<PKey<Private>>) {
     let dir = pebble_directory().await;
 
     let mut builder = AccountBuilder::new(dir.clone());
-    let account = builder
+    builder
       .contact(vec!["mailto:hello@lcas.dev".to_string()])
-      .terms_of_service_agreed(true)
-      .build()
-      .await
-      .unwrap();
+      .terms_of_service_agreed(true);
+    if let Some(p) = pkey {
+        builder.private_key(p);
+    }
+
+    let account = builder.build().await.unwrap();
 
     assert!(!account.id.is_empty());
 
@@ -226,6 +228,17 @@ mod tests {
     assert!(!account.id.is_empty());
     assert_eq!(account.status, AccountStatus::Valid);
     assert_eq!(account2.status, AccountStatus::Valid);
+  }
+
+  #[tokio::test]
+  async fn test_account_creation_pebble_rsa() {
+      test_account_creation_pebble(None).await;
+  }
+
+  #[tokio::test]
+  async fn test_account_creation_pebble_ec() {
+      let pkey = gen_ec_p256_private_key().unwrap();
+      test_account_creation_pebble(Some(pkey)).await;
   }
 
   #[tokio::test]

--- a/src/order.rs
+++ b/src/order.rs
@@ -191,7 +191,7 @@ fn gen_csr(
   stack.push(san_extension)?;
   builder.add_extensions(&stack)?;
 
-  builder.set_pubkey(&pkey)?;
+  builder.set_pubkey(pkey)?;
   builder.sign(pkey, MessageDigest::sha256())?;
 
   Ok(builder.build())


### PR DESCRIPTION
Fixes #22 by adding support for P-256 account keys (the default remains RSA).

Take this with a good amount of "I don't know what I'm doing here": I do not consider myself to be qualified to write cryptographic code. However, this passes both the included tests with pebble, and my bespoke integration tests with pebble through [agnos](https://github.com/krtab/agnos). In any case, the worst we can do here is form an invalid signature, which the server will reject, I guess?

Took the liberty to do a minor refactoring, because my initial attempt to add P-256 was quite ugly; fixed a few Clippy lints while I was at it.